### PR TITLE
Set back auto_item parameter

### DIFF
--- a/NewsLanguage.php
+++ b/NewsLanguage.php
@@ -65,6 +65,12 @@ class NewsLanguage extends Frontend
 				if ($objItem->numRows)
 				{
 					$arrGet['url']['items'] = $objItem->alias ? $objItem->alias : $objItem->id;
+
+					// Set back the auto_item parameter
+					if ($GLOBALS['TL_CONFIG']['useAutoItem'] && isset($_GET['auto_item']))
+					{
+						$arrGet['url']['auto_item'] = $objItem->alias ? $objItem->alias : $objItem->id;
+					}
 				}
         	}
         }


### PR DESCRIPTION
If `useAutoItem` is enabled and set, update the `auto_item` parameter after successful search for an accordingly news entry in the target language to the new value.

Probably fixes #4 and #5.
